### PR TITLE
85 cqlreplicator on glue set replication starting timestamp

### DIFF
--- a/glue/README.MD
+++ b/glue/README.MD
@@ -8,9 +8,7 @@ jobs of CQLReplicator.
 Each glue job (tile) is tasked with handling a specific subset of primary keys (250K per tile) to distribute migration
 workload evenly across Glue data processing units.
 A single replication glue job (AWS Glue DPU - 0.25X) can push up to 1500 WCUs per second against the target table in
-Amazon
-Keyspaces.
-This allows for easy estimation of the final traffic against Amazon Keyspaces.
+Amazon Keyspaces. This allows for easy estimation of the final traffic against Amazon Keyspaces.
 
 ![](architecture-glue.png "CQLReplicator on Glue")
 
@@ -168,6 +166,19 @@ In order to reduce AWS Glue costs after the historical workload moved to the tar
    --src-keyspace ks_test_cql_replicator --src-table test_cql_replicator \
    --trg-keyspace ks_test_cql_replicator --trg-table test_cql_replicator --override-rows-per-worker 500000`
 
+### Point in time replication
+
+if you want to replicate your data from a timestamp simply add the flag `--start-replication-from` followed by
+the timestamp to your command line:
+
+```shell
+   cqlreplicator --state request-stop --tiles 8 --landing-zone s3://cql-replicator-1234567890-us-west-2  \
+                 --writetime-column col1 --region us-west-2 \
+                 --src-keyspace ks_test_cql_replicator --src-table test_cql_replicator \
+                 --trg-keyspace ks_test_cql_replicator --trg-table test_cql_replicator \
+                 --start-replication-from 1706408365278858
+```
+
 ## Replicate workload to Amazon OpenSearch (preview) or Amazon MemoryDB
 
 In order to connect to Amazon OpenSearch or Amazon MemoryDB you need configure `/conf/OpenSearchConnector.conf`
@@ -182,7 +193,7 @@ cqlreplicator --state init --sg '"sg-1"' \
                            --subnet "subnet-XXXXXXX" 
                            --region "us-west-2" \ 
                            --az "us-west-1a" \
-                           --glue-iam-role "GlueOMS" \
+                           --glue-iam-role "glue-oss-replication" \
                            --target-type opensearch \
                            --target-sg "sg-2" \ 
                            --target-subnet "subnet-YYYYYY" \
@@ -196,7 +207,7 @@ cqlreplicator --state init --sg '"sg-1"' \
                            --subnet "subnet-XXXXXXX" 
                            --region "us-west-2" \ 
                            --az "us-west-1a" \
-                           --glue-iam-role "GlueOMS" \
+                           --glue-iam-role "glue-memorydb-replication" \
                            --target-type memorydb \
                            --target-sg "sg-2" \ 
                            --target-subnet "subnet-YYYYYY" \

--- a/glue/bin/cqlreplicator
+++ b/glue/bin/cqlreplicator
@@ -40,6 +40,7 @@ TARGET_TYPE=keyspaces
 SKIP_GLUE_CONNECTOR=false
 SKIP_KEYSPACES_LEDGER=false
 JSON_MAPPING=""
+REPLICATION_POINT_IN_TIME=0
 OS=$(uname -a | awk '{print $1}')
 
 # Progress bar configuration
@@ -487,6 +488,7 @@ function Start_Discovery {
   log "WRITE TIME COLUMN:" $WRITETIME_COLUMN
   log "TTL COLUMN:" $TTL_COLUMN
   log "ROWS PER DPU:" $ROWS_PER_WORKER
+  log "START REPLICATING FROM: $REPLICATION_POINT_IN_TIME (0 is disabled)"
   local workers=$((1 + TILES / 2))
   log "Checking if the discovery job is already running..."
   check_discovery_runs "true"
@@ -503,6 +505,7 @@ function Start_Discovery {
         "--TARGET_TBL":"'$TARGET_TBL'",
         "--WRITETIME_COLUMN":"'$WRITETIME_COLUMN'",
         "--OFFLOAD_LARGE_OBJECTS":"'$OFFLOAD_LARGE_OBJECTS_B64'",
+        "--REPLICATION_POINT_IN_TIME":"'$REPLICATION_POINT_IN_TIME'",
         "--TTL_COLUMN":"'$TTL_COLUMN'"}' --output text)
      JOBS+=("$rs")
   fi
@@ -528,6 +531,7 @@ function Start_Replication {
           "--TARGET_TBL":"'$TARGET_TBL'",
           "--WRITETIME_COLUMN":"'$WRITETIME_COLUMN'",
           "--OFFLOAD_LARGE_OBJECTS":"'$OFFLOAD_LARGE_OBJECTS_B64'",
+          "--REPLICATION_POINT_IN_TIME":"'$REPLICATION_POINT_IN_TIME'",
           "--TTL_COLUMN":"'$TTL_COLUMN'"}' --output text)
        JOBS+=("$rs")
       sleep $COOLING_PERIOD
@@ -707,6 +711,10 @@ while (( "$#" )); do
       JSON_MAPPING="$2"
       shitf 2
       ;;
+    --start-replication-from)
+      REPLICATION_POINT_IN_TIME="$2"
+      shift 2
+      ;;
     --override-rows-per-worker)
       ROWS_PER_WORKER="$2"
       shift 2
@@ -774,6 +782,10 @@ if [[ $STATE == cleanup ]]; then
 fi
 
 if [[ $STATE == stats ]]; then
+  check_input "$SOURCE_KS" "ERROR: source keyspace name is empty, must be provided"
+  check_input "$SOURCE_TBL" "ERROR: source table name is empty, must be provided"
+  check_input "$S3_LANDING_ZONE" "ERROR: landing zone must be provided"
+  check_input "$AWS_REGION" "ERROR: landing zone must be provided"
   # the barrier without checking if the discovery job is running
   barrier "false"
   tile=0


### PR DESCRIPTION
*Issue #, if available:*
#92 #90 #85 

*Description of changes:*

- Added support for point in time replication with provided timestamp up front 
- Added support for boolean type in primary
- Added support for multiple retries for the S3 client for `putStats` 
- Updated README.MD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
