### PR TITLE
125 lz4 decompression for unknown original size

### DIFF
--- a/glue/README.MD
+++ b/glue/README.MD
@@ -134,7 +134,7 @@ Before running the migration process
 configure [lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html)
 for the S3 bucket to delete objects after expiration. The xref column should be present in the source and the target
 tables before running the cqlreplicator.
-The payload will be compressed by [LZ4](https://fuchsia.googlesource.com/third_party/lz4/+/refs/tags/v1.7.5/README.md)and stored in Base64 format on the S3 bucket.
+The payload will be compressed by [LZ4](https://fuchsia.googlesource.com/third_party/lz4/+/refs/tags/v1.7.5/README.md) with a leading 4 bytes (Int) and stored in Base64 format on the S3 bucket.
 
 ```shell
 ./cqlreplicator --state run --tiles 8 --landing-zone s3://cql-replicator-1234567890-us-west-2 --src-keyspace ks_test_cql_replicator \

--- a/glue/README.MD
+++ b/glue/README.MD
@@ -305,7 +305,10 @@ the timestamp to your command line:
 ## Compress selected columns
 
 To minimize the size of large columns in the target table, enable the `compressionConfig` in the json mapping.
-All selected columns will be encoded in JSON format and compressed by LZ4 compressor.
+All selected columns will be encoded in JSON format and compressed by LZ4 fast compressor.
+
+Note that the CQLReplicator will add a leading Int to the compressed value. In this case, you will know the exact size of 
+a buffer you should use for decompression on the client side.
 
 ```shell
 ./cqlreplicator --state run --tiles 4 --landing-zone "s3://cql-replicator-1234567890-us-east-1-dev" --writetime-column col2 \

--- a/glue/README.MD
+++ b/glue/README.MD
@@ -307,7 +307,7 @@ the timestamp to your command line:
 To minimize the size of large columns in the target table, enable the `compressionConfig` in the json mapping.
 All selected columns will be encoded in JSON format and compressed by LZ4 fast compressor.
 
-Note that the CQLReplicator will add a leading Int to the compressed value. In this case, you will know the exact size of 
+Note that the CQLReplicator will add a leading 4 bytes (Int) to the compressed value. In this case, you will know the exact size of 
 a buffer you should use for decompression on the client side.
 
 ```shell

--- a/glue/sbin/keyspaces/CQLReplicator.scala
+++ b/glue/sbin/keyspaces/CQLReplicator.scala
@@ -49,6 +49,7 @@ import java.util.Base64
 import java.nio.charset.StandardCharsets
 import java.time.format.DateTimeFormatter
 import java.time.Duration
+import java.nio.ByteBuffer
 import org.joda.time.LocalDateTime
 import net.jpountz.lz4.{LZ4Compressor, LZ4Factory}
 
@@ -491,7 +492,9 @@ object GlueApp {
       val compressedOutput = new Array[Byte](maxCompressedLength)
       val compressedLength: Int = compressor.compress(inputBytes, 0, inputBytes.length, compressedOutput, 0, maxCompressedLength)
       val compressedBytes = compressedOutput.slice(0, compressedLength)
-      compressedBytes
+      val sizePrefix = ByteBuffer.allocate(4).putInt(input.length).array()
+      // Add leading 4 bytes (Int) in the compressed value byte array. #125
+      sizePrefix ++ compressedBytes
     }
 
     def stopRequested(bucket: String): Boolean = {


### PR DESCRIPTION
*Issue #, if available:*
#125 

*Description of changes:*

**[Compression feature]** Added a leading 4 bytes (Int) to compressed payload to know the exact size of a buffer on the client size before decompression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
