### PR TITLE
142 extend support for multiple data types in rowtostatement

### DIFF
--- a/glue/README.MD
+++ b/glue/README.MD
@@ -238,8 +238,8 @@ To obtain the number of replicated rows after the back filling phase, run the fo
 
 ```shell
 cqlreplicator --state stats --landing-zone s3://cql-replicator-1234567890-us-west-2 \
---src-keyspace ks_test_cql_replicator --src-table test_cql_replicator \
---region us-west-2 --replication-stats-enabled
+              --src-keyspace ks_test_cql_replicator --src-table test_cql_replicator \
+              --region us-west-2 --replication-stats-enabled
 ```
 
 ```
@@ -381,6 +381,23 @@ in the json mapping during the `run`, for example,
                                           }}
                                         }'
 ```
+## Filtering primary keys
+There use-cases when you need to filter out certain keys during the migration phase 
+
+```shell
+./cqlreplicator --state run --tiles 4 --landing-zone "s3://cql-replicator-1234567890-us-east-1-dev" --writetime-column col2 \
+                                      --region us-east-1 --src-keyspace ks_test_cql_replicator --src-table test_cql_replicator \ 
+                                      --trg-keyspace ks_test_cql_replicator --trg-table test_cql_replicator_filtered_columns \
+                                      --json-mapping '{
+                                          "keyspaces": {
+                                            "transformation": {        
+                                            "enabled": true,        
+                                            "filterExpression": "client_id NOT like \"ACME%\"" 
+                                            }
+                                          }
+                                        }'
+```
+Note: You can use only primary key columns in the `filterExpression` a the `filterExpression` should be defined as the Spark SQL Expression.  
 
 ## Enable the custom JSON Serializer
 
@@ -415,20 +432,20 @@ and `useCustomSerializer`:`true`.
 ### Limitations
 
 The custom JSON serializer supports the following data types: boolean, int, text, ascii, bigint, blob, counter, date,
-decimal,
-double,float,timestamp,smallint,timeuuid,uuid, and tinyint.
+decimal, double,float,timestamp,smallint,timeuuid,uuid, and tinyint.
 
 ## Know issues
 
 | Error Message/Issue                                                                                                           | CW Discovery logs | CW Replication logs | Work around                                                                                                                                                                                                     | Requires the ledger cleanup |
 |-------------------------------------------------------------------------------------------------------------------------------|-------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
 | 1. No space left on device                                                                                                    | Yes               | No                  | Scale out the replication process by increasing the number of tiles                                                                                                                                             | Yes                         |
-| 2. No space left on device                                                                                                    | Yes               | No                  | Scale up the the DPU for the discovery glue job by replacing 1.X to 2.X in `cqlreplicator.sh`                                                                                                                   | No                          |
+| 2. No space left on device                                                                                                    | Yes               | No                  | Add the following parameter `--discovery-worker-type G.2X` to scale up the the DPU for the discovery glue job by replacing 1.X to 2.X                                                                           | No                          |
 | 3. You have limited IPs in the subnet                                                                                         | Yes               | Yes                 | Create a new Glue connection with the new subnet and attach the CQLReplicator Glue Job                                                                                                                          | No                          |
-| 4. You have limited IPs in the subnet                                                                                         | Yes               | Yes                 | Add the following param `--override-rows-per-worker 500000` to reduce the number of DPUs/IPs                                                                                                                    | No                          |
+| 4. You have limited IPs in the subnet                                                                                         | Yes               | Yes                 | Add the following parameter `--override-rows-per-worker 500000` to reduce the number of DPUs/IPs                                                                                                                | No                          |
 | 5. Cassandra timeout during read query at consistency ONE <br/>(1 responses were required but only 0 replica responded) <br/> | Yes               | No                  | Reduce page size and increase the request timeout in CassandraConnector.conf                                                                                                                                    | No                          |
 | 6. Cassandra timeout during read query at consistency ONE <br/>(1 responses were required but only 0 replica responded) <br/> | Yes               | No                  | Create a materialized view in the Cassandra cluster with the same primary keys and one regular column.<br/> Configure the CQLReplicator to use this materialized view as the source for the primary keys. <br/> | No                          |
 | 7. Cassandra timeout during read query at consistency ONE <br/>(1 responses were required but only 0 replica responded) <br/> | Yes               | No                  | Increase `read_request_timeout_in_ms`, `range_request_timeout_in_ms`, and `request_timeout_in_ms` in the cassandra.yaml and run rolling restart of the Cassandra cluster.                                       | No                          |
+| 8. java.lang.OutOfMemoryError: GC overhead limit exceeded                                                                     | Yes               | No                  | Increase the number of DPUs for the discovery job by using the parameter, e.g. `--override-discovery-workers 12`                                                                                                |                             |
 
 ### Work around for `Cassandra timeout during read query at consistency ONE` with Cassandra materialized view
 

--- a/glue/README.MD
+++ b/glue/README.MD
@@ -5,10 +5,10 @@ This migration approach ensures zero downtime, no code compilation, predictable 
 ## Architecture
 This solution offers customers the flexibility to scale the migration workload up and out by deploying multiple Glue
 jobs of CQLReplicator.
-Each glue job (tile) is tasked with handling a specific subset of primary keys (250K per one data processing unit
+Each glue job (tile) is tasked with handling a specific subset of primary keys (1M per one data processing unit
 G.025X) to distribute migration
 workload evenly across data processing units.
-A single replication glue job (AWS Glue DPU - 0.25X) can push up to 1500 WCUs per second against the target table in
+A single replication glue job (AWS Glue DPU - 0.25X) can push up to 1000 WCUs (io size 1KB) per second against the target table in
 Amazon Keyspaces. This allows for easy estimation of the final traffic against Amazon Keyspaces.
 
 ![](architecture-glue.png "CQLReplicator on Glue")
@@ -65,10 +65,11 @@ a S3 bucket, a Glue job, migration keyspace, and ledger table.
   If you don't supply it, init process will try to create a new bucket to store config, JAR artifacts, and intermediate
   files
 - `--target-type` - this is an optional parameter, the default value is `keyspaces`, available options: `parquet`
-  , `memorydb`, `opensearch` (preview)
+  , `memorydb`,and `opensearch`
 - `--skip-glue-connector` - this is an optional parameter allows you to skip the glue connector creation step
 - `--skip-keyspaces-ledger` - in case if you don't want to create/delete the ledger (the internal table in Amazon
-  Keyspaces migration.ledger) 
+  Keyspaces migration.ledger)
+- `--main-script-landing` - use this flag if you want to store the main script in the `s3://your-landing-zone/script/CQLReplicator.scala`
 
 ```shell
     cqlreplicator --state init --region us-west-2 \ 
@@ -382,7 +383,7 @@ in the json mapping during the `run`, for example,
                                         }'
 ```
 ## Filtering primary keys
-There use-cases when you need to filter out certain keys during the migration phase 
+There are use-cases when you need to filter out some certain keys during the migration phase, for example: 
 
 ```shell
 ./cqlreplicator --state run --tiles 4 --landing-zone "s3://cql-replicator-1234567890-us-east-1-dev" --writetime-column col2 \
@@ -397,7 +398,7 @@ There use-cases when you need to filter out certain keys during the migration ph
                                           }
                                         }'
 ```
-Note: You can use only primary key columns in the `filterExpression` a the `filterExpression` should be defined as the Spark SQL Expression.  
+Note: You can use only primary key columns in the `filterExpression` a the `filterExpression` should be defined as [the Spark SQL Expression](https://spark.apache.org/docs/3.3.0/api/sql/index.html).  
 
 ## Enable the custom JSON Serializer
 

--- a/glue/bin/cqlreplicator
+++ b/glue/bin/cqlreplicator
@@ -7,8 +7,9 @@
 MIGRATOR_VERSION=0.3
 DESCRIPTION="Toolbox for Amazon Keyspaces"
 JOB_NAME=CQLReplicator
-TILES=2
+TILES=1
 WORKER_TYPE=G.025X
+DISCOVERY_WORKER_TYPE=G.1X
 TILE=""
 PROCESS_TYPE_DISCOVERY=discovery
 PROCESS_TYPE_REPLICATION=replication
@@ -24,6 +25,7 @@ INCR_TRAFFIC=240
 JOBS=()
 DISCOVERED_TOTAL=0
 REPLICATED_TOTAL=0
+OVERRIDE_DISCOVERY_WORKERS=0
 BASE_FOLDER=$(pwd -L)
 AWS_REGION=""
 SUBNET=""
@@ -35,7 +37,7 @@ TRG_SG=""
 GLUE_IAM_ROLE=""
 AWS_ACCOUNT=""
 KEYS_PER_TILE=0
-ROWS_PER_WORKER=250000
+ROWS_PER_WORKER=1000000
 TARGET_TYPE=keyspaces
 SKIP_GLUE_CONNECTOR=false
 SKIP_KEYSPACES_LEDGER=false
@@ -54,7 +56,7 @@ REPLAY_LOG="false"
 
 # Progress bar configuration
 PS=40
-PCC="⣿"
+PCC="|"
 PCU="-"
 PPS=2
 
@@ -106,6 +108,16 @@ function check_input() {
   return 0
 }
 
+function max_value() {
+  local rs=0
+  if [[ $1 -gt $2 ]]; then
+    rs="$1"
+  else
+    rs="$2"
+  fi
+  echo $rs
+}
+
 function confirm() {
   local msg=$1
   read -r -p "$msg" choice
@@ -141,7 +153,8 @@ function check_discovery_runs() {
    # mode = true, if discovery job is not running return 0
    # mode = false, if discovery job is not running return 1
    mode=$1
-   rs=$(aws glue get-job-runs --job-name "CQLReplicator$DEFAULT_ENV" --region "$AWS_REGION" --query 'JobRuns[?JobRunState==`RUNNING`] | [].Arguments | [?"--PROCESS_TYPE"==`discovery`]' | jq '.[0]["--SOURCE_TBL"] == "'"$SOURCE_TBL"'" and .[0]["--SOURCE_KS"] == "'"$SOURCE_KS"'"')
+   rs=$(aws glue get-job-runs --job-name "CQLReplicator$DEFAULT_ENV" --region "$AWS_REGION"  \
+    --query 'JobRuns[?JobRunState==`RUNNING`] | [].Arguments | [?"--PROCESS_TYPE"==`discovery`] | [?"--SOURCE_KS"==`'"$SOURCE_KS"'`] | [?"--SOURCE_TBL"==`'"$SOURCE_TBL"'`]' | jq 'length != 0')
 
    if [[ $rs == "$mode" ]]; then
        log "ERROR: The discovery job has failed, check AWS Glue logs"
@@ -154,9 +167,11 @@ function check_replication_runs() {
    local tile
    local rs
    tile=$1
-   rs=$(aws glue get-job-runs --job-name "CQLReplicator$DEFAULT_ENV" --region "$AWS_REGION" --query 'JobRuns[?JobRunState==`RUNNING`] | [].Arguments | [?"--PROCESS_TYPE"==`replication`]' | jq '.[] | select(."--TILE"=="'"$tile"'" and ."--SOURCE_TBL"=="'"$SOURCE_TBL"'" and ."--SOURCE_KS"=="'"$SOURCE_KS"'")')
-   if [[ -n "${rs}" ]]; then
-     log "ERROR: Replication job is already running per tile $tile for" $SOURCE_KS.$SOURCE_TBL
+   rs=$(aws glue get-job-runs --job-name "CQLReplicator$DEFAULT_ENV" --region "$AWS_REGION" \
+    --query 'length(JobRuns[?JobRunState==`RUNNING`] | [].Arguments | [?"--PROCESS_TYPE"==`replication`] | [?"--SOURCE_KS"==`'"$SOURCE_KS"'`] | [?"--SOURCE_TBL"==`'"$SOURCE_TBL"'`] | [?"--TILE"==`"'"$tile"'"`])')
+
+   if [ "${rs}" -ne 0 ]; then
+     log "ERROR: Replication job is already running per tile $tile for $SOURCE_KS.$SOURCE_TBL"
      log "$rs"
      return 1
   fi
@@ -164,10 +179,10 @@ function check_replication_runs() {
 }
 
 function check_num_tiles() {
-  if [[ $TILES -lt 2 ]]; then
-        log "Total number of tiles should be => 2"
+  if [[ $TILES -lt 1 ]]; then
+        log "Total number of tiles should be => 1"
         exit 1
-    fi
+  fi
     return 0
 }
 
@@ -525,7 +540,14 @@ function Start_Discovery {
   log "START REPLICATING FROM: $REPLICATION_POINT_IN_TIME (0 is disabled)"
   log "SAFE MODE: $SAFE_MODE"
   log "WORKER_TYPE: $WORKER_TYPE"
-  local workers=$((1 + TILES / 2))
+  local workers=0
+  if [[ $OVERRIDE_DISCOVERY_WORKERS == 0 ]]; then
+    max_value2=2
+    max_value1=$((1 + TILES / 2))
+    workers=$(max_value $max_value1 $max_value2)
+  else
+    workers=$OVERRIDE_DISCOVERY_WORKERS
+  fi
   log "Checking if the discovery job is already running..."
   if [[ $CLEANUP_REQUESTED == "true" ]]; then
     log "The ledger is going to be cleaned up"
@@ -536,7 +558,7 @@ function Start_Discovery {
   if check_discovery_runs "true"; then
     Delete_Stop_Event_D
     log "Starting the discovery job..."
-    rs=$(aws glue start-job-run --job-name "$JOB_NAME$DEFAULT_ENV" --worker-type G.1X --number-of-workers "$workers" --region "$AWS_REGION" --arguments '{"--PROCESS_TYPE":"'$PROCESS_TYPE_DISCOVERY'",
+    rs=$(aws glue start-job-run --job-name "$JOB_NAME$DEFAULT_ENV" --worker-type "$DISCOVERY_WORKER_TYPE" --number-of-workers "$workers" --region "$AWS_REGION" --arguments '{"--PROCESS_TYPE":"'$PROCESS_TYPE_DISCOVERY'",
         "--TILE":"0",
         "--TOTAL_TILES":"'$TILES'",
         "--S3_LANDING_ZONE":"'$S3_LANDING_ZONE'",
@@ -674,7 +696,7 @@ function Delete_Stop_Event_D {
 }
 
 function Delete_Stop_Event_R {
-  aws s3api delete-object --bucket "${S3_LANDING_ZONE:5}" --key "$SOURCE_KS/$SOURCE_TBL/replication/"$1"/stopRequested" --region "$AWS_REGION"
+  aws s3api delete-object --bucket "${S3_LANDING_ZONE:5}" --key "$SOURCE_KS/$SOURCE_TBL/replication/$1/stopRequested" --region "$AWS_REGION"
   # Debug
   # log "s3://${S3_LANDING_ZONE:5}/$SOURCE_KS/$SOURCE_TBL/replication/$1/stopRequested"
 }
@@ -718,6 +740,14 @@ while (( "$#" )); do
       ;;
     --worker-type|-wt)
       WORKER_TYPE="$2"
+      shift 2
+      ;;
+    --discovery-worker-type|-dwt)
+      DISCOVERY_WORKER_TYPE="$2"
+      shift 2
+      ;;
+    --override-discovery-workers|-odw)
+      OVERRIDE_DISCOVERY_WORKERS="$2"
       shift 2
       ;;
     --landing-zone|--lz)

--- a/glue/bin/cqlreplicator
+++ b/glue/bin/cqlreplicator
@@ -5,7 +5,7 @@
 #
 # Migration parameters
 MIGRATOR_VERSION=0.3
-DESCRIPTION="Toolbox for Amazon Keyspaces"
+DESCRIPTION="Migration Toolbox"
 JOB_NAME=CQLReplicator
 TILES=1
 WORKER_TYPE=G.025X
@@ -53,6 +53,7 @@ DEFAULT_ENV=""
 MAVEN_REPO=https://repo1.maven.org/maven2
 CLEANUP_REQUESTED="false"
 REPLAY_LOG="false"
+MAIN_SCRIPT_LANDING="false"
 
 # Progress bar configuration
 PS=40
@@ -385,7 +386,13 @@ function Init {
   # Source C*/K*
   uploader_helper "CassandraConnector.conf" 1 2 5
 
-  local glue_bucket_artifacts=s3://aws-glue-assets-"$AWS_ACCOUNT"-"$AWS_REGION"
+  local glue_bucket_artifacts
+  if [[ "$MAIN_SCRIPT_LANDING" = false ]]; then
+    glue_bucket_artifacts=s3://aws-glue-assets-"$AWS_ACCOUNT"-"$AWS_REGION"
+  else
+    glue_bucket_artifacts="$S3_LANDING_ZONE"
+  fi
+
   if aws s3 ls "$glue_bucket_artifacts"/scripts/ --region "$AWS_REGION" > /dev/null --region "$AWS_REGION"
   then
     aws s3 cp "$path_to_scala"/CQLReplicator.scala "$glue_bucket_artifacts"/scripts/CQLReplicator$DEFAULT_ENV.scala --region "$AWS_REGION" > /dev/null
@@ -450,7 +457,7 @@ function Init {
        aws glue create-job \
            --name "CQLReplicator$DEFAULT_ENV" \
            --role "$GLUE_IAM_ROLE" \
-           --description "$DESCRIPTION -> $TARGET_TYPE" \
+           --description "$DESCRIPTION for $TARGET_TYPE" \
            --glue-version "4.0" \
            --number-of-workers 2 \
            --worker-type "G.1X" \
@@ -753,6 +760,10 @@ while (( "$#" )); do
     --landing-zone|--lz)
       S3_LANDING_ZONE="$2"
       shift 2
+      ;;
+    --main-script-landing|--msl)
+      MAIN_SCRIPT_LANDING="true"
+      shift 1
       ;;
     --writetime-column|--wc)
       WRITETIME_COLUMN="$2"


### PR DESCRIPTION
*Issue #, if available:*
#142 #141
*Description of changes:*
- Added support for data types: bigint, timeuuid, varint, ascii, and time in primary key
- Added support for filtering out of certain primary keys during replication process
- Added support for storing the main script in landing zone bucket
- Now you can override a number of discovery DPUs and set DPU type (G.025X, G.2X, and etc)
- Updated README.MD
- Reduced the number of retries from 256 to 64
- Fixed the minor issues in `cqlreplicator.sh`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
