### PR TITLE
update replayLogs to omit IF NOT EXISTS

### DIFF
--- a/glue/docs/keyspaces/README.MD
+++ b/glue/docs/keyspaces/README.MD
@@ -242,6 +242,8 @@ Best practises:
 To replay failed rows:
 1. Stop the CQLReplicator with `request-stop`
 2. Run it again with `--replay-log` - this option allows you to replay failed operations during the replication phase.
+   If the the original run included the `--json-mapping '{"keyspaces": { "readBeforeWrite": true }}'` parameter ensure 
+   that this is included in the run.
 
 ## Stop migration process
 To stop migration process gracefully run the following command for all tiles:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `replayLogs` function wants to add `IF NOT EXISTS` to the end of all CQL in the DLQ however if the DLQ was written with `{"keyspaces": { "readBeforeWrite": true }}` option then it would duplicate `IF NOT EXISTS`.

This PR will omit `IF NOT EXISTS` on `replayLogs` if `{"keyspaces": { "readBeforeWrite": true }}` is supplied alongside `--replay-log` as assumed in the [README.md](https://github.com/aws-samples/cql-replicator/tree/main/glue/docs/keyspaces#handling-failed-rows)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
