### PR TITLE
The modified code explicitly handles null TTL values by setting them …

### DIFF
--- a/glue/sbin/keyspaces/CQLReplicator.scala
+++ b/glue/sbin/keyspaces/CQLReplicator.scala
@@ -931,7 +931,10 @@ object GlueApp {
           jsonMapping4s.keyspaces.largeObjectsConfig.enabled match {
             case false =>
               val backToJsonRow = backToCQLStatementWithoutTTL(json4sRow)
-              val ttlVal = getTTLvalue(json4sRow)
+              val ttlVal = {
+                val rawTtl = getTTLvalue(json4sRow)
+                if (rawTtl == null) 0 else rawTtl
+              }
               val cqlStatement = s"INSERT INTO $trgKeyspaceName.$trgTableName JSON '$backToJsonRow'$cas USING TTL $ttlVal"
               if (maxStatementsPerBatch > 1)
                 fl.add(cqlStatement)
@@ -940,7 +943,10 @@ object GlueApp {
             case _ =>
               val updatedJsonRow = offloadToS3(json4sRow, s3ClientOnPartition, whereClause)
               val backToJsonRow = backToCQLStatementWithoutTTL(updatedJsonRow)
-              val ttlVal = getTTLvalue(json4sRow)
+              val ttlVal = {
+                val rawTtl = getTTLvalue(json4sRow)
+                if (rawTtl == null) 0 else rawTtl
+              }
               val cqlStatement = s"INSERT INTO $trgKeyspaceName.$trgTableName JSON '$backToJsonRow'$cas USING TTL $ttlVal"
               if (maxStatementsPerBatch > 1)
                 fl.add(cqlStatement)


### PR DESCRIPTION
…to 0, which ensures that records with null TTL values will be inserted with TTL 0 (meaning they won't expire) rather than potentially causing errors or unexpected behavior

*Issue #, if available:*

#195 

*Description of changes:*

The modified code now explicitly handles null TTL values by setting them to 0, which ensures that records with null TTL values will be inserted with TTL 0 (meaning they won't expire) rather than potentially causing errors or unexpected behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
