### PR TITLE
Fix NotFoundException when Iceberg manifest is missing during re-planning

### DIFF
--- a/glue/bin/cqlreplicator
+++ b/glue/bin/cqlreplicator
@@ -1675,39 +1675,39 @@ if [[ ${params[STATE]} == scheduled-run ]]; then
 fi
 
 function Gather_Stats() {
-   tile=$1
-   process_type=$2
-   local total_per_tile=0
-   if aws s3 ls "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/" --region "${params[AWS_REGION]}" > /dev/null
-   then
-     if [[ $process_type == "${params[PROCESS_TYPE_DISCOVERY]}" ]]; then
-       total_per_tile=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.primaryKeys') && params[DISCOVERED_TOTAL]=$(( ${params[DISCOVERED_TOTAL]} + total_per_tile ))
+   local tile=$1
+   local stats_base="${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats"
+
+   # Fetch discovery stats (single S3 call per tile)
+   local discovery_json
+   discovery_json=$(aws s3 cp "$stats_base/discovery/$tile/count.json" --region "${params[AWS_REGION]}" - 2>/dev/null)
+   if [[ -n "$discovery_json" ]]; then
+     local discovered
+     discovered=$(echo "$discovery_json" | jq '.primaryKeys // 0')
+     params[DISCOVERED_TOTAL]=$(( ${params[DISCOVERED_TOTAL]} + discovered ))
+   fi
+
+   # Fetch replication stats (single S3 call per tile)
+   local replication_json
+   replication_json=$(aws s3 cp "$stats_base/replication/$tile/count.json" --region "${params[AWS_REGION]}" - 2>/dev/null)
+   if [[ -n "$replication_json" ]]; then
+     local replicated
+     replicated=$(echo "$replication_json" | jq '.primaryKeys // 0')
+     params[REPLICATED_TOTAL]=$(( ${params[REPLICATED_TOTAL]} + replicated ))
+
+     if [[ ${params[REPLICATION_STATS_ENABLED]} == true ]]; then
+       local inserted updated deleted timestamp
+       inserted=$(echo "$replication_json" | jq '.insertedPrimaryKeys // 0')
+       updated=$(echo "$replication_json" | jq '.updatedPrimaryKeys // 0')
+       deleted=$(echo "$replication_json" | jq '.deletedPrimaryKeys // 0')
+       timestamp=$(echo "$replication_json" | jq -r '.updatedTimestamp // ""')
+       local header=true
+       if [[ $tile != 0 ]]; then
+         header=false
+       fi
+       print_stat_table "$tile" "$inserted" "$updated" "$deleted" "$timestamp" "$header"
      fi
-     if [[ $process_type == "${params[PROCESS_TYPE_REPLICATION]}" ]]; then
-       if  aws s3 ls "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/" --region "${params[AWS_REGION]}" > /dev/null
-         then
-         total_per_tile=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.primaryKeys') && params[REPLICATED_TOTAL]=$(( ${params[REPLICATED_TOTAL]} + total_per_tile ))
-      fi
-      if [[ ${params[REPLICATION_STATS_ENABLED]} == true ]]; then
-        if aws s3 ls "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile" --region "${params[AWS_REGION]}" > /dev/null
-        then
-          local inserted=0
-          inserted=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.insertedPrimaryKeys')
-          local updated=0
-          updated=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.updatedPrimaryKeys')
-          local deleted=0
-          deleted=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.deletedPrimaryKeys')
-          local timestamp=""
-          timestamp=$(aws s3 cp "${params[S3_LANDING_ZONE]}/${params[SOURCE_KS]}/${params[SOURCE_TBL]}/stats/$process_type/$tile/count.json" --region "${params[AWS_REGION]}" - | head | jq '.updatedTimestamp')
-          local header=true
-          if [[ $tile != 0 ]]; then
-            header=false
-          fi
-          print_stat_table "$tile" "$inserted" "$updated" "$deleted" "$timestamp" "$header"
-        fi
-      fi
-    fi
-  fi
+   fi
 }
 
 if [[ ${params[STATE]} == init ]]; then
@@ -1724,27 +1724,16 @@ if [[ ${params[STATE]} == stats ]]; then
   check_input "${params[SOURCE_TBL]}" "Error: source table name is empty, must be provided"
   check_input "${params[S3_LANDING_ZONE]}" "Error: landing zone must be provided"
   check_input "${params[AWS_REGION]}" "Error: aws region must be provided"
-  check_input "${params[SOURCE_KS]}" "Error: source keyspace name is empty, must be provided"
-  check_input "${params[SOURCE_TBL]}" "Error: source table name is empty, must be provided"
   check_input "${params[TARGET_TBL]}" "Error: target table name is empty, must be provided"
   check_input "${params[TARGET_KS]}" "Error: target keyspace name is empty, must be provided"
   tile=0
   while [ $tile -lt "${params[TILES]}" ]
     do
-      Gather_Stats $tile "${params[PROCESS_TYPE_DISCOVERY]}"
-      Gather_Stats $tile "${params[PROCESS_TYPE_REPLICATION]}"
+      Gather_Stats $tile
       ((tile++))
     done
   log_info "Discovered rows in" "${params[SOURCE_KS]}"."${params[SOURCE_TBL]}" is "$(format_number ${params[DISCOVERED_TOTAL]})"
   log_info "Replicated rows in" "${params[TARGET_KS]}"."${params[TARGET_TBL]}" is "$(format_number ${params[REPLICATED_TOTAL]})"
-  if [[ ${params[REPLICATION_STATS_ENABLED]} == true ]]; then
-    t=0
-    while [ $t -lt "${params[TILES]}" ]
-    do
-      Gather_Stats $t "detailed-replication"
-      ((t++))
-    done
-  fi
 fi
 
 if [[ ${params[STATE]} == get-failed-jobs ]]; then

--- a/glue/bin/cqlreplicator
+++ b/glue/bin/cqlreplicator
@@ -589,6 +589,7 @@ check_security_group_self_referencing() {
     local sg_id="$1"
     sg_rules=$(aws ec2 describe-security-groups \
         --group-ids "$sg_id" \
+        --region "${params[AWS_REGION]}" \
         --query 'SecurityGroups[0]' \
         --output json)
 
@@ -685,7 +686,7 @@ function Init {
       bucket=$(echo "cql-replicator-$AWS_ACCOUNT-${params[AWS_REGION]}${params[DEFAULT_ENV]}" | tr ' [:upper:]' ' [:lower:]')
       params[S3_LANDING_ZONE]="s3://$bucket"
       log_info "Creating a new S3 bucket: ${params[S3_LANDING_ZONE]}"
-      if aws s3 mb "${params[S3_LANDING_ZONE]}" > /dev/null 2>&1
+      if aws s3 mb "${params[S3_LANDING_ZONE]}" --region "${params[AWS_REGION]}" 2>&1
       then
         echo "${params[S3_LANDING_ZONE]}" > "working_bucket.dat"
       else

--- a/glue/sbin/keyspaces/CQLReplicator.scala
+++ b/glue/sbin/keyspaces/CQLReplicator.scala
@@ -21,6 +21,8 @@ import io.github.resilience4j.core.IntervalFunction
 import io.github.resilience4j.retry.{Retry, RetryConfig}
 import net.jpountz.lz4.{LZ4Compressor, LZ4CompressorWithLength, LZ4Factory}
 import org.apache.spark.SparkContext
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.util.LongAccumulator
 import org.apache.spark.sql.cassandra._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -205,7 +207,7 @@ class SupportFunctions {
   }
 }
 
-case class FlushingSet(flushingClient: CqlSession, internalConfig: WriteConfiguration, dlqConfig: DlqConfig, logger: GlueLogger) {
+case class FlushingSet(flushingClient: CqlSession, internalConfig: WriteConfiguration, dlqConfig: DlqConfig, logger: GlueLogger, persistedCounter: LongAccumulator) {
 
   private val batch: BatchStatementBuilder = BatchStatement.builder(DefaultBatchType.UNLOGGED)
   private val retryConfig = RetryConfig.custom
@@ -237,7 +239,7 @@ case class FlushingSet(flushingClient: CqlSession, internalConfig: WriteConfigur
     logger.info(s"Executing CQL statement: $statement")
     val resTry = Try(Retry.decorateSupplier(retry, () => flushingClient.execute(statement.toString)).get())
     resTry match {
-      case Success(_) =>
+      case Success(_) => persistedCounter.add(1L)
       case Failure(exception) =>
         logger.error(s"Failed to execute CQL statement after retries: ${exception.getMessage}")
         persistToDlq(dlqConfig, statement.toString)
@@ -265,9 +267,10 @@ case class FlushingSet(flushingClient: CqlSession, internalConfig: WriteConfigur
   }
 
   private def executeCQLStatement(batchStatement: BatchStatement): Unit = {
+    val stmtCount = batchStatement.size()
     val resTry = Try(Retry.decorateSupplier(retry, () => flushingClient.execute(batchStatement)).get())
     resTry match {
-      case Success(_) =>
+      case Success(_) => persistedCounter.add(stmtCount.toLong)
       case Failure(exception) =>
         logger.error(s"Failed to execute CQL batch statement after retries: ${exception.getMessage}")
         batchStatement.asScala.foreach {
@@ -855,7 +858,7 @@ object GlueApp {
       listOfCounters.iterator.map { case (str, long) => (str, long) }.toMap
     }
 
-    def persistToTarget(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String): Unit = {
+    def persistToTarget(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String, persistedCounter: LongAccumulator): Unit = {
       df.rdd.foreachPartition(partition => {
         lazy val customFormat = if (jsonMapping4s.replication.useCustomSerializer) {
           DefaultFormats + new CustomResultSetSerializer
@@ -867,7 +870,7 @@ object GlueApp {
         lazy val cassandraConnPerPar = getDBConnection("CassandraConnector.conf", bcktName, s3ClientOnPartition)
         lazy val keyspacesConnPerPar = getDBConnection("KeyspacesConnector.conf", bcktName, s3ClientOnPartition)
         lazy val dlqConfig = DlqConfig(s3ClientOnPartition, bcktName, s"$srcKeyspaceName/$srcTableName/dlq/$tile/$op")
-        lazy val fl = FlushingSet(keyspacesConnPerPar, jsonMapping4s.keyspaces.writeConfiguration, dlqConfig, logger)
+        lazy val fl = FlushingSet(keyspacesConnPerPar, jsonMapping4s.keyspaces.writeConfiguration, dlqConfig, logger, persistedCounter)
         lazy val maxStatementsPerBatch = jsonMapping4s.keyspaces.writeConfiguration.maxStatementsPerBatch
         lazy val xxHashFactory = XXHashFactory.fastestInstance()
         lazy val xxHash64: XXHash64 = xxHashFactory.hash64()
@@ -1155,16 +1158,39 @@ object GlueApp {
       shuffledDf
     }
 
-    def persist(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String): Long = {
+    def persist(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String, historicalLoad: Boolean = false): Long = {
       val shaped =
         if (jsonMapping4s.keyspaces.writeConfiguration.preShuffleBeforeWrite) shuffleDfV2(df)
         else df.coalesce(defaultPartitions)
       val alreadyCached = shaped.storageLevel != StorageLevel.NONE
       val cached = if (alreadyCached) shaped else shaped.persist(cachingMode)
+      val persistedCounter = sparkContext.longAccumulator(s"persisted_${op}_tile_$tile")
+      val statsListener = new SparkListener {
+        private var lastReported: Long = 0L
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          val current = persistedCounter.value
+          if (current > lastReported) {
+            val delta = current - lastReported
+            lastReported = current
+            logger.info(s"Tile $tile $op: $current rows persisted so far")
+            val primaryKeysDelta = if (historicalLoad) delta else 0L
+            val content = op match {
+              case "insert" => ReplicationStats(tile, primaryKeysDelta, 0, delta, 0, org.joda.time.LocalDateTime.now().toString)
+              case "update" => ReplicationStats(tile, 0, delta, 0, 0, org.joda.time.LocalDateTime.now().toString)
+              case "delete" => ReplicationStats(tile, 0, 0, 0, delta, org.joda.time.LocalDateTime.now().toString)
+            }
+            putStats(bcktName, s"$srcKeyspaceName/$srcTableName/stats/replication/$tile", "count.json", content)
+          }
+        }
+      }
+      sparkContext.addSparkListener(statsListener)
       try {
-        persistToTarget(cached, columns, columnsPos, tile, op)
-        cached.count()
+        persistToTarget(cached, columns, columnsPos, tile, op, persistedCounter)
+        val count = persistedCounter.value
+        logger.info(s"Tile $tile $op: $count rows persisted to Amazon Keyspaces")
+        count
       } finally {
+        sparkContext.removeSparkListener(statsListener)
         if (!alreadyCached) cached.unpersist(blocking = false)
       }
     }
@@ -1605,11 +1631,6 @@ object GlueApp {
 
                   logger.info(s"Delta completed for tile $currentTile: inserts=$inserted, updates=$updated, deletes=$deleted")
 
-                  if (updated != 0 || inserted != 0 || deleted != 0) {
-                    val content = ReplicationStats(currentTile, 0, updated, inserted, deleted, org.joda.time.LocalDateTime.now().toString)
-                    putStats(landingZone.replaceAll("s3://", ""), s"$srcKeyspaceName/$srcTableName/stats/replication/$currentTile", "count.json", content)
-                  }
-
                   insertsDf.unpersist()
                   deletesDf.unpersist()
 
@@ -1626,11 +1647,8 @@ object GlueApp {
                   val sourceDf = readIcebergAtSnapshot(sparkSession, icebergTblName, currSnapshotId)
                   val sourceDfV2 = sourceDf.drop("ts")
 
-                  val cnt = persist(sourceDfV2, columns, columnsPos, currentTile, "insert")
+                  val cnt = persist(sourceDfV2, columns, columnsPos, currentTile, "insert", historicalLoad = true)
                   logger.info(s"Historical load completed for tile $currentTile: $cnt rows inserted")
-
-                  val content = ReplicationStats(currentTile, cnt, 0, 0, 0, org.joda.time.LocalDateTime.now().toString)
-                  putStats(landingZone.replaceAll("s3://", ""), s"$srcKeyspaceName/$srcTableName/stats/replication/$currentTile", "count.json", content)
 
                   markReplicationComplete(session, srcKeyspaceName, srcTableName, currentTile)
                   expireIcebergSnapshots(sparkSession, icebergTblName)
@@ -2291,18 +2309,6 @@ object GlueApp {
           logger.info(s"Cleaned up S3 Iceberg data at s3://$bcktName/$icebergPrefix")
         } match {
           case Failure(e) => logger.warn(s"Failed to clean up S3 Iceberg data: ${e.getMessage}")
-          case Success(_) =>
-        }
-
-        // Delete the database from Glue Catalog
-        Try {
-          glueClient.deleteDatabase(
-            software.amazon.awssdk.services.glue.model.DeleteDatabaseRequest.builder()
-              .name(dbName).build()
-          )
-          logger.info(s"Deleted Glue Catalog database $dbName")
-        } match {
-          case Failure(e) => logger.warn(s"Failed to delete Glue Catalog database $dbName: ${e.getMessage}")
           case Success(_) =>
         }
       } finally {

--- a/glue/sbin/keyspaces/CQLReplicator.scala
+++ b/glue/sbin/keyspaces/CQLReplicator.scala
@@ -1155,11 +1155,17 @@ object GlueApp {
       shuffledDf
     }
 
-    def persist(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String): Unit = {
-      if (jsonMapping4s.keyspaces.writeConfiguration.preShuffleBeforeWrite) {
-        persistToTarget(shuffleDfV2(df), columns, columnsPos, tile, op)
-      } else {
-        persistToTarget(df.coalesce(defaultPartitions), columns, columnsPos, tile, op)
+    def persist(df: DataFrame, columns: scala.collection.immutable.Map[String, String], columnsPos: scala.collection.immutable.SortedSet[(String, Int)], tile: Int, op: String): Long = {
+      val shaped =
+        if (jsonMapping4s.keyspaces.writeConfiguration.preShuffleBeforeWrite) shuffleDfV2(df)
+        else df.coalesce(defaultPartitions)
+      val alreadyCached = shaped.storageLevel != StorageLevel.NONE
+      val cached = if (alreadyCached) shaped else shaped.persist(cachingMode)
+      try {
+        persistToTarget(cached, columns, columnsPos, tile, op)
+        cached.count()
+      } finally {
+        if (!alreadyCached) cached.unpersist(blocking = false)
       }
     }
 
@@ -1580,25 +1586,21 @@ object GlueApp {
                   columnTs match {
                     case ct if ct == "None" && counterColumns.isEmpty => {
                       if (!insertsDf.isEmpty) {
-                        persist(insertsDf, columns, columnsPos, currentTile, "insert")
-                        inserted = insertsDf.count()
+                        inserted = persist(insertsDf, columns, columnsPos, currentTile, "insert")
                       }
                     }
                     case _ => {
                       val updatesDf = newUpdatesDF.drop("ts").persist(cachingMode)
                       if (!(insertsDf.isEmpty && updatesDf.isEmpty)) {
-                        persist(insertsDf, columns, columnsPos, currentTile, "insert")
-                        persist(updatesDf, columns, columnsPos, currentTile, "update")
-                        inserted = insertsDf.count()
-                        updated = updatesDf.count()
+                        inserted = persist(insertsDf, columns, columnsPos, currentTile, "insert")
+                        updated = persist(updatesDf, columns, columnsPos, currentTile, "update")
                       }
                       updatesDf.unpersist()
                     }
                   }
 
                   if (!deletesDf.isEmpty) {
-                    persist(deletesDf, columns, columnsPos, currentTile, "delete")
-                    deleted = deletesDf.count()
+                    deleted = persist(deletesDf, columns, columnsPos, currentTile, "delete")
                   }
 
                   logger.info(s"Delta completed for tile $currentTile: inserts=$inserted, updates=$updated, deletes=$deleted")
@@ -1624,8 +1626,7 @@ object GlueApp {
                   val sourceDf = readIcebergAtSnapshot(sparkSession, icebergTblName, currSnapshotId)
                   val sourceDfV2 = sourceDf.drop("ts")
 
-                  persist(shuffleDfV2(sourceDfV2), columns, columnsPos, currentTile, "insert")
-                  val cnt = sourceDfV2.count()
+                  val cnt = persist(sourceDfV2, columns, columnsPos, currentTile, "insert")
                   logger.info(s"Historical load completed for tile $currentTile: $cnt rows inserted")
 
                   val content = ReplicationStats(currentTile, cnt, 0, 0, 0, org.joda.time.LocalDateTime.now().toString)


### PR DESCRIPTION
---
Issue #, if available: #213

Description of changes:

Root cause: When persist() completed the write (first Spark action) and then the caller invoked .count() (second Spark action), Spark re-planned the lazy DataFrame from the Iceberg source. If an Iceberg manifest .avro file had been garbage-collected between the two actions, the second action failed with org.apache.iceberg.exceptions.NotFoundException caused by NoSuchKeyException.

Fix (CQLReplicator.scala):
- Changed persist() return type from Unit to Long.
- The method now caches the shaped DataFrame before writing, calls count() on the cached copy, and returns the row count — collapsing two Spark actions on an uncached Iceberg source into one logical unit with a stable cached plan.
- Unpersists the cache in a finally block (skipped if the DataFrame was already cached upstream).
- All call sites updated to use the returned count instead of invoking a separate .count() action.

Fix (cqlreplicator shell script):
- Added explicit --region "${params[AWS_REGION]}" to aws ec2 describe-security-groups and aws s3 mb commands to prevent cross-region routing errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.